### PR TITLE
dein.vimのインストール方法をインストーラ使用からgit cloneへ変更

### DIFF
--- a/vim_setting/.vimrc
+++ b/vim_setting/.vimrc
@@ -62,12 +62,16 @@ command! Config :e $MYVIMRC
 command! Tomls :e ~/.vim/rc
 
 "# プラグイン設定 ---------------------------------------------------------------------------------
-"## deinの設定(カラースキームの設定はこの処理が終わった後に記入する事)
 set runtimepath+=~/.vim/dein/repos/github.com/Shougo/dein.vim
+" ## deinのインストール
 " プラグインのインストールディレクトリ
 let s:dein_dir=expand('~/.vim/dein')
 let s:dein_repo_dir=s:dein_dir . '/repos/github.com/Shougo/dein.vim'
+if !isdirectory(s:dein_repo_dir)
+  execute '!git clone https://github.com/Shougo/dein.vim' s:dein_repo_dir
+endif
 
+"## deinの設定(カラースキームの設定はこの処理が終わった後に記入する事)
 if dein#load_state(s:dein_dir)
   call dein#begin(s:dein_dir)
 

--- a/vim_setting/install.sh
+++ b/vim_setting/install.sh
@@ -48,14 +48,14 @@ function main()
     install_gnu_global
   fi
 
-  # deinのインストール
-  if [ ! -d ~/.vim/dein ]; then
-    # deinがインストールされていなければインストール
-    mkdir ~/.vim/dein
-    curl https://raw.githubusercontent.com/Shougo/dein.vim/master/bin/installer.sh > ./installer.sh
-    sh ./installer.sh ~/.vim/dein
-    rm -f installer.sh
-  fi
+#  # deinのインストール
+#  if [ ! -d ~/.vim/dein ]; then
+#    # deinがインストールされていなければインストール
+#    mkdir ~/.vim/dein
+#    curl https://raw.githubusercontent.com/Shougo/dein.vim/master/bin/installer.sh > ./installer.sh
+#    sh ./installer.sh ~/.vim/dein
+#    rm -f installer.sh
+#  fi
 
   # プラグインのインストール
   vim -c ":q"


### PR DESCRIPTION
提供されているインストーラが仕様変更により使用不可になったため、.vimrc側でインストールするように変更した