### PR TITLE
[tmux] set-optionをsetに統一化と初回起動時のエラーメッセージ対応

### DIFF
--- a/tmux_setting/.tmux.conf
+++ b/tmux_setting/.tmux.conf
@@ -31,11 +31,7 @@ bind -r K resize-pane -U 5 # prefix+Kで上に5文字分移動
 bind -r L resize-pane -R 5 # prefix+Lで右に5文字分移動
 
 ## ペイン番号の表示時間を10秒に変更
-set display-panes-time 10000
-
-## 非アクティブペインのみ白っぽく変更
-set -g window-style bg=colour242
-set -g window-active-style bg=colour0
+set -g display-panes-time 10000
 
 # マウス有効
 setw -g mouse on
@@ -45,9 +41,13 @@ setw -g mouse on
 set -g default-terminal screen-256color
 set -g terminal-overrides xterm:colors=256
 
+## 非アクティブペインのみ白っぽく変更
+set -g window-style bg=colour242
+set -g window-active-style bg=colour0
+
 ## ステータスバーの設定
 set -g status-position top
-set-option -g status-bg colour212
+set -g status-bg colour212
 set -g status-interval 1 # ステータスバーの更新を1秒毎に行う
 
 ### 左パネルの設定
@@ -63,13 +63,16 @@ set -g window-status-current-style bg=colour32 # アクティブなウィンド�
 set -g status-right-length 50 # 表示可能文字数
 set -g status-right "%A, %B %d, %Y %T" # week, month day, year, 時分秒を表示
 
-set-option -g history-limit 5000
+set -g history-limit 5000
 set-window-option -g mode-keys vi
 
 # コピーモードのコピー先のクリップボードを指定
 if-shell "uname -a | grep Microsoft" '\
     bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "clip.exe"; \
     '
+
+set -g utf8-cjk on
+set -g utf8-emoji on
 
 # プラグインリスト
 # プラグインマネージャー


### PR DESCRIPTION
setとset-optionが混在していた
tmuxの初回起動時に`no current session`が表示されていたのをいい加減対応